### PR TITLE
Fix request hangs

### DIFF
--- a/ryu/base/app_manager.py
+++ b/ryu/base/app_manager.py
@@ -154,7 +154,7 @@ class RyuApp(object):
         self.event_handlers = {}        # ev_cls -> handlers:list
         self.observers = {}     # ev_cls -> observer-name -> states:set
         self.threads = []
-        self.events = hub.Queue(128)
+        self.events = hub.Queue(-1)
         if hasattr(self.__class__, 'LOGGER_NAME'):
             self.logger = logging.getLogger(self.__class__.LOGGER_NAME)
         else:


### PR DESCRIPTION
If the handler is blocked by any flow action waiting for the barrier reply, and the receive queue is flooded with other messages, the barrier reply may not be queued then the handler will be blocked forever.

Changes the queue to infinite size will fix the problem.
