### PR TITLE
encode chassis_id_prefix to bytes

### DIFF
--- a/ryu/topology/switches.py
+++ b/ryu/topology/switches.py
@@ -473,7 +473,9 @@ class LLDPPacket(object):
             raise LLDPPacket.LLDPUnknownFormat(
                 msg='unknown chassis id subtype %d' % tlv_chassis_id.subtype)
         chassis_id = tlv_chassis_id.chassis_id
-        if not chassis_id.startswith(LLDPPacket.CHASSIS_ID_PREFIX):
+        if type(LLDPPacket.CHASSIS_ID_PREFIX) is str:
+            chassis_id_prefix  = str.encode(LLDPPacket.CHASSIS_ID_PREFIX)
+        if not chassis_id.startswith(chassis_id_prefix):
             raise LLDPPacket.LLDPUnknownFormat(
                 msg='unknown chassis id format %s' % chassis_id)
         src_dpid = str_to_dpid(chassis_id[LLDPPacket.CHASSIS_ID_PREFIX_LEN:])


### PR DESCRIPTION
The controller was throwing error that first arg of startswith must be bytes when I tried to run shortestpath implementation of controller.
![screenshot from 2015-10-04 10-19-41](https://cloud.githubusercontent.com/assets/2370073/10268812/92cde1cc-6a81-11e5-8815-61b1af0fcb97.png)
