### PR TITLE
Fix JSON RPC notifications to not expect a reply

### DIFF
--- a/ryu/contrib/tinyrpc/client.py
+++ b/ryu/contrib/tinyrpc/client.py
@@ -41,7 +41,12 @@ class RPCClient(object):
         """
         req = self.protocol.create_request(method, args, kwargs, one_way)
 
-        return self._send_and_handle_reply(req).result
+        if one_way is False:
+            result = self._send_and_handle_reply(req).result
+        else:
+            self.transport.send_message(req.serialize())
+            result = None
+        return result
 
     def get_proxy(self, prefix='', one_way=False):
         """Convenience method for creating a proxy.


### PR DESCRIPTION
Previously, the RPCClient waited for a server reply when sending a [one-way notification message](http://www.jsonrpc.org/specification#notification)). As the server "MUST NOT reply to a Notification," the RPCClient should not wait for a reply.
