### PR TITLE
topology/switches: Fix delete port can't immediately remove link.

### DIFF
--- a/ryu/topology/switches.py
+++ b/ryu/topology/switches.py
@@ -717,7 +717,6 @@ class Switches(app_manager.RyuApp):
             # LOG.debug('A port was deleted.' +
             #           '(datapath id = %s, port number = %s)',
             #           dp.id, ofpport.port_no)
-            self.port_state[dp.id].remove(ofpport.port_no)
             self.send_event_to_observers(
                 event.EventPortDelete(Port(dp.id, dp.ofproto, ofpport)))
 
@@ -729,6 +728,8 @@ class Switches(app_manager.RyuApp):
                 self.ports.del_port(port)
                 self._link_down(port)
                 self.lldp_event.set()
+
+            self.port_state[dp.id].remove(ofpport.port_no)
 
         else:
             assert reason == dp.ofproto.OFPPR_MODIFY


### PR DESCRIPTION
If remove port data from self.port_state first,
self.get_port method can't get the port data,
this problem will cause link can't immediately be removed.
This patch remove port data after get_port and link delete.

Signed-off-by: Yu Ren <j6y4u4xup6@gmail.com>