### PR TITLE
Fix UT when running in python 3.7 env

### DIFF
--- a/ryu/tests/test_lib.py
+++ b/ryu/tests/test_lib.py
@@ -267,6 +267,8 @@ def add_method(cls, method_name, method):
     method.__name__ = method_name
     if six.PY3:
         methodtype = types.MethodType(method, cls)
+        if not hasattr(method, "__qualname__"):
+            method.__qualname__ = "%s.%s" % (cls.__qualname__, method_name)
     else:
         methodtype = types.MethodType(method, None, cls)
     setattr(cls, method_name, methodtype)


### PR DESCRIPTION
Due to change [1] in python 3.7 one of ryu's unit tests
was failing with this version of interpreter. It was like that
because of missing __qualname__ attribute in functools.partial
object.
This patch fixes it by adding such attribute if it's not
set already.

[1] https://github.com/python/cpython/pull/4496