### PR TITLE
Bugfix: now multiple switches can connect with TLS

### DIFF
--- a/ryu/lib/hub.py
+++ b/ryu/lib/hub.py
@@ -127,21 +127,22 @@ if HUB_TYPE == 'eventlet':
                 self.server = eventlet.listen(listen_info)
 
             if ssl_args:
-                def wrap_and_handle(sock, addr):
-                    ssl_args.setdefault('server_side', True)
-                    if 'ssl_ctx' in ssl_args:
-                        ctx = ssl_args.pop('ssl_ctx')
-                        ctx.load_cert_chain(ssl_args.pop('certfile'),
-                                            ssl_args.pop('keyfile'))
-                        if 'cert_reqs' in ssl_args:
-                            ctx.verify_mode = ssl_args.pop('cert_reqs')
-                        if 'ca_certs' in ssl_args:
-                            ctx.load_verify_locations(ssl_args.pop('ca_certs'))
+                ssl_args.setdefault('server_side', True)
+                if 'ssl_ctx' in ssl_args:
+                    ctx = ssl_args.pop('ssl_ctx')
+                    ctx.load_cert_chain(ssl_args.pop('certfile'),
+                                        ssl_args.pop('keyfile'))
+                    if 'cert_reqs' in ssl_args:
+                        ctx.verify_mode = ssl_args.pop('cert_reqs')
+                    if 'ca_certs' in ssl_args:
+                        ctx.load_verify_locations(ssl_args.pop('ca_certs'))
+                    def wrap_and_handle_ctx(sock, addr):
                         handle(ctx.wrap_socket(sock, **ssl_args), addr)
-                    else:
+                    self.handle = wrap_and_handle_ctx
+                else:
+                    def wrap_and_handle_ssl(sock, addr):
                         handle(ssl.wrap_socket(sock, **ssl_args), addr)
-
-                self.handle = wrap_and_handle
+                    self.handle = wrap_and_handle_ssl
             else:
                 self.handle = handle
 


### PR DESCRIPTION
This fixes a bug in RYU StreamServer where SSLContext was modified for
each connection (by popping keys from ssl_args). Now the SSLContext of the server 
socket is modified only once in __init__