### PR TITLE
Add .readthedocs.yml.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,11 @@
+version: 2
+build:
+  image: latest
+python:
+  version: 3.6
+  install:
+    - method: pip
+      path: .
+sphinx:
+  configuration: doc/source/conf.py
+formats: all


### PR DESCRIPTION
Building the Ryu API docs started failing after we migrated readthedocs over to the faucet foundation's account.

This was because the default readthedocs settings don't build Ryu's sphinx correctly. Add a .readthedocs.yml configuration to prevent this issue in future.

fixes #91 