### PR TITLE
Deprecate older python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ matrix:
     - python: 3.6
       env: TOX_ENV=autopep8
 
-    - python: 2.7
-      env: TOX_ENV=pycodestyle
-    - python: 2.7
-      env: TOX_ENV=py27
-
     - python: 3.5
       env: TOX_ENV=py35
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,7 @@ classifier =
     Topic :: System :: Networking
     Natural Language :: English
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# a bug workaround.  http://bugs.python.org/issue15881
-try:
-    import multiprocessing
-except ImportError:
-    pass
-
 import setuptools
 import ryu.hooks
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,6 @@ commands =
 commands =
   python ryu/tests/integrated/run_test.py
 
-[testenv:py27]
-commands =
-  {[testenv]commands}
-  {[testenv:scenario]commands}
-
 [testenv:py36]
 commands =
   {[testenv]commands}


### PR DESCRIPTION
Deprecate using Ryu with python2.

We will no longer test on python2.7 and drop pypi metadata suggesting we support python2

Related to #95 