### PR TITLE
We don't support msgpack 1.0.0 yet.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9.0.0), python-all (>= 2.6), python-sphinx
 Build-Depends-Indep:
  python-eventlet,
  python-lxml,
- python-msgpack (>= 0.3.0),
+ python-msgpack (>= 0.3.0), python-msgpack (< 1.0.0),
  python-netaddr,
  python-oslo.config (>= 1:1.2.0),
  python-paramiko,
@@ -28,7 +28,7 @@ Section: python
 Depends:
  python-eventlet,
  python-lxml,
- python-msgpack (>= 0.3.0),
+ python-msgpack (>= 0.3.0), python-msgpack (< 1.0.0),
  python-netaddr,
  python-oslo.config (>= 1:1.2.0),
  python-paramiko,

--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -2,7 +2,7 @@
 # following issue.
 # https://github.com/eventlet/eventlet/issues/401
 eventlet!=0.18.3,>=0.18.2,!=0.20.1,!=0.21.0,!=0.23.0
-msgpack>=0.3.0  # RPC library, BGP speaker(net_cntl)
+msgpack>=0.3.0,<1.0.0  # RPC library, BGP speaker(net_cntl)
 netaddr
 oslo.config>=2.5.0
 ovs>=2.6.0  # OVSDB


### PR DESCRIPTION
Msgpack 1.0.0 has changed their API, and we don't support it yet:

```
Traceback (most recent call last):
  File "/home/travis/build/gizmoguy/ryu/ryu/tests/unit/lib/test_rpc.py", line 86, in setUp
    disp_table=table)
  File "/home/travis/build/gizmoguy/ryu/ryu/lib/rpc.py", line 98, in __init__
    encoder = MessageEncoder()
  File "/home/travis/build/gizmoguy/ryu/ryu/lib/rpc.py", line 43, in __init__
    self._packer = msgpack.Packer(encoding='utf-8', use_bin_type=True)
  File "msgpack/_packer.pyx", line 118, in msgpack._cmsgpack.Packer.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
```

Make sure msgpack <1.0.0 gets installed.