### PR TITLE
Workaround eventlet Python3.7 SSLContext wrap issue

### DIFF
--- a/ryu/controller/controller.py
+++ b/ryu/controller/controller.py
@@ -30,6 +30,7 @@ from socket import TCP_NODELAY
 from socket import SHUT_WR
 from socket import timeout as SocketTimeout
 import ssl
+import sys
 
 from ryu import cfg
 from ryu.lib import hub
@@ -168,6 +169,12 @@ class OpenFlowController(object):
             if not hasattr(ssl, 'SSLContext'):
                 # anything less than python 2.7.9 supports only TLSv1
                 # or less, thus we choose TLSv1
+                ssl_args = {'ssl_version': ssl.PROTOCOL_TLSv1}
+            elif sys.version_info >= (3, 7,):
+                # On Python3.7+ we can't wrap an SSLContext due to this bug:
+                # https://github.com/eventlet/eventlet/issues/526
+                # Lets assume the system has a new enough OpenSSL that
+                # SSL is fully disabled.
                 ssl_args = {'ssl_version': ssl.PROTOCOL_TLSv1}
             else:
                 # from 2.7.9 and versions 3.4+ ssl context creation is

--- a/ryu/controller/controller.py
+++ b/ryu/controller/controller.py
@@ -68,6 +68,7 @@ CONF.register_cli_opts([
     cfg.StrOpt('ctl-privkey', default=None, help='controller private key'),
     cfg.StrOpt('ctl-cert', default=None, help='controller certificate'),
     cfg.StrOpt('ca-certs', default=None, help='CA certificates'),
+    cfg.StrOpt('ciphers', default=None, help='list of ciphers to enable'),
     cfg.ListOpt('ofp-switch-address-list', item_type=str, default=[],
                 help='list of IP address and port pairs (default empty). '
                      'e.g., "127.0.0.1:6653,[::1]:6653"'),
@@ -188,6 +189,9 @@ class OpenFlowController(object):
                 ssl_args = {'ssl_ctx': ssl.SSLContext(getattr(ssl, p))}
                 # Restrict non-safe versions
                 ssl_args['ssl_ctx'].options |= ssl.OP_NO_SSLv3 | ssl.OP_NO_SSLv2
+
+            if CONF.ciphers is not None:
+                ssl_args['ciphers'] = CONF.ciphers
 
             if CONF.ca_certs is not None:
                 server = StreamServer((CONF.ofp_listen_host,

--- a/ryu/tests/unit/controller/test_controller.py
+++ b/ryu/tests/unit/controller/test_controller.py
@@ -191,6 +191,7 @@ class TestOpenFlowController(unittest.TestCase):
         conf_mock.ofp_ssl_listen_port = port
         conf_mock.ofp_listen_host = "127.0.0.1"
         conf_mock.ca_certs = None
+        conf_mock.ciphers = None
         conf_mock.ctl_cert = os.path.join(this_dir, 'cert.crt')
         conf_mock.ctl_privkey = os.path.join(this_dir, 'cert.key')
         c = controller.OpenFlowController()


### PR DESCRIPTION
* Workaround for #94 
* Includes #85 
* Allows user to configure cipher list