### PR TITLE
Resolve a syntax warning

### DIFF
--- a/ryu/lib/packet/cfm.py
+++ b/ryu/lib/packet/cfm.py
@@ -268,7 +268,7 @@ class cc_message(operation):
         self._opcode = CFM_CC_MESSAGE
         assert rdi in [0, 1]
         self.rdi = rdi
-        assert interval is not 0
+        assert interval != 0
         self.interval = interval
         self.seq_num = seq_num
         assert 1 <= mep_id <= 8191


### PR DESCRIPTION
Newer versions of python emit a syntax warning for this assertion.

```
SyntaxWarning: "is not" with a literal. Did you mean "!="?
  assert interval is not 0
```