### PR TITLE
Add Support for Python 3.9

### DIFF
--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,7 +30,7 @@ features (it's not a must though).
 
 Python version and libraries
 ============================
-* Python 3.5, 3.6, 3.7, 3.8:
+* Python 3.5, 3.6, 3.7, 3.8, 3.9:
 
   Ryu supports multiple Python versions.  CI tests on GitHub Actions is running
   on these versions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Operating System :: Unix
 keywords =
     openflow

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,pypy,pycodestyle,autopep8
+envlist = py35,py36,py37,py38,py39,pypy,pycodestyle,autopep8
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
   3.6: py36, pycodestyle, autopep8
   3.7: py37
   3.8: py38
+  3.9: py39
 
 [testenv]
 deps =


### PR DESCRIPTION
Hello,

we would like to run Ryu on Python 3.9, therefore support for running on Python 3.9 should be added. This MR adds this and also adds a few lines that were missing showing the support for Python 3.8 when testing on 3.8 was added with https://github.com/faucetsdn/ryu/commit/9b002e0eece436ad72e2ec8b250620f78277c567

The Github Action tests pass without any changes.