### PR TITLE
Support msgpack 1.0.0 and later.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9.0.0), python-all (>= 2.6), python-sphinx
 Build-Depends-Indep:
  python-eventlet,
  python-lxml,
- python-msgpack (>= 0.4.0), python-msgpack (< 1.0.0),
+ python-msgpack (>= 0.4.0),
  python-netaddr,
  python-oslo.config (>= 1:1.2.0),
  python-paramiko,
@@ -28,7 +28,7 @@ Section: python
 Depends:
  python-eventlet,
  python-lxml,
- python-msgpack (>= 0.4.0), python-msgpack (< 1.0.0),
+ python-msgpack (>= 0.4.0),
  python-netaddr,
  python-oslo.config (>= 1:1.2.0),
  python-paramiko,

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 9.0.0), python-all (>= 2.6), python-sphinx
 Build-Depends-Indep:
  python-eventlet,
  python-lxml,
- python-msgpack (>= 0.3.0), python-msgpack (< 1.0.0),
+ python-msgpack (>= 0.4.0), python-msgpack (< 1.0.0),
  python-netaddr,
  python-oslo.config (>= 1:1.2.0),
  python-paramiko,
@@ -28,7 +28,7 @@ Section: python
 Depends:
  python-eventlet,
  python-lxml,
- python-msgpack (>= 0.3.0), python-msgpack (< 1.0.0),
+ python-msgpack (>= 0.4.0), python-msgpack (< 1.0.0),
  python-netaddr,
  python-oslo.config (>= 1:1.2.0),
  python-paramiko,

--- a/ryu/lib/rpc.py
+++ b/ryu/lib/rpc.py
@@ -40,8 +40,16 @@ class MessageEncoder(object):
 
     def __init__(self):
         super(MessageEncoder, self).__init__()
-        self._packer = msgpack.Packer(encoding='utf-8', use_bin_type=True)
-        self._unpacker = msgpack.Unpacker(encoding='utf-8')
+        if msgpack.version >= (1, 0, 0):
+            self._packer = msgpack.Packer()
+            # The strict_map_key=False option is required to use int keys in
+            # maps; it is disabled by default to prevent hash collision denial
+            # of service attacks (hashdos) in scenarios where an attacker can
+            # control the keys to be hashed.
+            self._unpacker = msgpack.Unpacker(strict_map_key=False)
+        else:
+            self._packer = msgpack.Packer(encoding='utf-8', use_bin_type=True)
+            self._unpacker = msgpack.Unpacker(encoding='utf-8')
         self._next_msgid = 0
 
     def _create_msgid(self):

--- a/ryu/services/protocols/bgp/net_ctrl.py
+++ b/ryu/services/protocols/bgp/net_ctrl.py
@@ -101,8 +101,16 @@ class RpcSession(Activity):
     def __init__(self, sock, outgoing_msg_sink_iter):
         self.peer_name = str(sock.getpeername())
         super(RpcSession, self).__init__(self.NAME_FMT % self.peer_name)
-        self._packer = msgpack.Packer(encoding='utf-8', use_bin_type=True)
-        self._unpacker = msgpack.Unpacker(encoding='utf-8')
+        if msgpack.version >= (1, 0, 0):
+            self._packer = msgpack.Packer()
+            # The strict_map_key=False option is required to use int keys in
+            # maps; it is disabled by default to prevent hash collision denial
+            # of service attacks (hashdos) in scenarios where an attacker can
+            # control the keys to be hashed.
+            self._unpacker = msgpack.Unpacker(strict_map_key=False)
+        else:
+            self._packer = msgpack.Packer(encoding='utf-8', use_bin_type=True)
+            self._unpacker = msgpack.Unpacker(encoding='utf-8')
         self._next_msgid = 0
         self._socket = sock
         self._outgoing_msg_sink_iter = outgoing_msg_sink_iter

--- a/ryu/services/protocols/bgp/net_ctrl.py
+++ b/ryu/services/protocols/bgp/net_ctrl.py
@@ -101,7 +101,7 @@ class RpcSession(Activity):
     def __init__(self, sock, outgoing_msg_sink_iter):
         self.peer_name = str(sock.getpeername())
         super(RpcSession, self).__init__(self.NAME_FMT % self.peer_name)
-        self._packer = msgpack.Packer(encoding='utf-8')
+        self._packer = msgpack.Packer(encoding='utf-8', use_bin_type=True)
         self._unpacker = msgpack.Unpacker(encoding='utf-8')
         self._next_msgid = 0
         self._socket = sock

--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -2,7 +2,7 @@
 # following issue.
 # https://github.com/eventlet/eventlet/issues/401
 eventlet!=0.18.3,>=0.18.2,!=0.20.1,!=0.21.0,!=0.23.0
-msgpack>=0.3.0,<1.0.0  # RPC library, BGP speaker(net_cntl)
+msgpack>=0.4.0,<1.0.0  # RPC library, BGP speaker(net_cntl)
 netaddr
 oslo.config>=2.5.0
 ovs>=2.6.0  # OVSDB

--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -2,7 +2,7 @@
 # following issue.
 # https://github.com/eventlet/eventlet/issues/401
 eventlet!=0.18.3,>=0.18.2,!=0.20.1,!=0.21.0,!=0.23.0
-msgpack>=0.4.0,<1.0.0  # RPC library, BGP speaker(net_cntl)
+msgpack>=0.4.0  # RPC library, BGP speaker(net_cntl)
 netaddr
 oslo.config>=2.5.0
 ovs>=2.6.0  # OVSDB


### PR DESCRIPTION
Support msgpack 1.0.0 and later; preserve support for older versions of msgpack by using runtime version checking.

See https://pypi.org/project/msgpack/1.0.0/ for breaking changes in version 1.0.