### PR TITLE
Enable bare minimum pytype + GHA (no ryu code changes). 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,3 +55,14 @@ setup-hooks =
 console_scripts =
     ryu-manager = ryu.cmd.manager:main
     ryu = ryu.cmd.ryu_base:main
+
+[pytype]
+inputs =
+    ryu/controller/
+disable =
+    attribute-error
+    import-error
+    key-error
+    module-attr
+keep-going =
+    1

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -4,4 +4,5 @@ mock
 nose
 pycodestyle
 pylint
+pytype
 formencode

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,pypy,pycodestyle,autopep8
+envlist = py35,py36,py37,py38,py39,pypy,pycodestyle,autopep8,pytype
 
 [gh-actions]
 python =
   3.5: py35
-  3.6: py36, pycodestyle, autopep8
+  3.6: py36, pycodestyle, autopep8, pytype
   3.7: py37
   3.8: py38
   3.9: py39
@@ -52,6 +52,14 @@ deps =
   autopep8
 commands =
   bash -c 'test -z "$(autopep8 --recursive --diff ryu/)"'
+
+[testenv:pytype]
+deps =
+  -U
+  --no-cache-dir
+  pytype
+commands =
+  pytype --jobs 2
 
 [pycodestyle]
 exclude = pbr-*,.venv,.tox,.git,doc,dist,tools,vcsversion.py,.pyc,ryu/contrib


### PR DESCRIPTION
Can easily add scope/remove ignored errors to make incremental cleanup progress.