### PR TITLE
Fix bug where path.source is set to VRF_TABLE (in vrf.py)

### DIFF
--- a/ryu/services/protocols/bgp/processor.py
+++ b/ryu/services/protocols/bgp/processor.py
@@ -36,6 +36,8 @@ from ryu.lib.packet.bgp import BGP_ATTR_ORIGIN_IGP
 from ryu.lib.packet.bgp import BGP_ATTR_ORIGIN_EGP
 from ryu.lib.packet.bgp import BGP_ATTR_ORIGIN_INCOMPLETE
 
+from ryu.services.protocols.bgp.constants import VRF_TABLE
+
 LOG = logging.getLogger('bgpspeaker.processor')
 
 
@@ -428,7 +430,7 @@ def _cmp_by_asn(local_asn, path1, path2):
     """
     def get_path_source_asn(path):
         asn = None
-        if path.source is None:
+        if path.source is None or path.source == VRF_TABLE:
             asn = local_asn
         else:
             asn = path.source.remote_as


### PR DESCRIPTION
```
20:15:21,496 ryu.lib.hub ERROR hub: uncaught exception: Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/ryu/lib/hub.py", line 60, in _launch
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/base.py", line 256, in start
    self._run(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/processor.py", line 99, in _run
    self._process_dest()
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/processor.py", line 116, in _process_dest
    next_dest.process()
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/info_base/base.py", line 421, in process
    self._process()
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/info_base/base.py", line 391, in _process
    new_best_path, reason = self._process_paths()
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/info_base/base.py", line 510, in _process_paths
    current_best_path, reason = self._compute_best_known_path()
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/info_base/base.py", line 613, in _compute_best_known_path
    next_path)
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/processor.py", line 252, in compute_best_path
    best_path = _cmp_by_asn(local_asn, path1, path2)
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/processor.py", line 437, in _cmp_by_asn
    p1_asn = get_path_source_asn(path1)
  File "/usr/local/lib/python3.6/site-packages/ryu/services/protocols/bgp/processor.py", line 434, in get_path_source_asn
    asn = path.source.remote_as
AttributeError: 'str' object has no attribute 'remote_as'
```

Happens when path.source is set to "vrf_table"