### PR TITLE
Fix major bug in child thread cleanup logic

### DIFF
--- a/ryu/services/protocols/bgp/base.py
+++ b/ryu/services/protocols/bgp/base.py
@@ -285,7 +285,7 @@ class Activity(object):
         """Stops all threads spawn by this activity.
         """
         for thread_name, thread in list(self._child_thread_map.items()):
-            if name is not None and thread_name is name:
+            if name is None or thread_name == name:
                 LOG.debug('%s: Stopping child thread %s',
                           self.name, thread_name)
                 thread.kill()


### PR DESCRIPTION
Without this fix, one cannot restart BGP Speaker instances