### PR TITLE
Add support for network namespaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,7 @@ Some functions of ryu require extra packages:
 - NETCONF requires paramiko
 - BGP speaker (SSH console) requires paramiko
 - Zebra protocol service (database) requires SQLAlchemy
+- Network namespaces for BGP sockets requires netns
 
 If you want to use these functions, please install the requirements::
 

--- a/ryu/services/protocols/bgp/base.py
+++ b/ryu/services/protocols/bgp/base.py
@@ -342,6 +342,7 @@ class Activity(object):
         addr, port = sock.getsockname()[:2]
         return self._canonicalize_ip(addr), str(port)
 
+    # XXX JvB not used
     def _create_listen_socket(self, family, loc_addr):
         s = socket.socket(family)
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -365,7 +366,7 @@ class Activity(object):
         For each connection `server_factory` starts a new protocol.
         """
         info = socket.getaddrinfo(loc_addr[0], loc_addr[1], socket.AF_UNSPEC,
-                                  socket.SOCK_STREAM, 0, socket.AI_PASSIVE)
+                                    socket.SOCK_STREAM, 0, socket.AI_PASSIVE)
         listen_sockets = {}
         for res in info:
             af, socktype, proto, _, sa = res
@@ -375,13 +376,11 @@ class Activity(object):
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 if af == socket.AF_INET6:
                     sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
-
                 sock.bind(sa)
                 sock.listen(50)
                 listen_sockets[sa] = sock
             except socket.error as e:
                 LOG.error('Error creating socket: %s', e)
-
                 if sock:
                     sock.close()
 

--- a/ryu/services/protocols/bgp/bgpspeaker.py
+++ b/ryu/services/protocols/bgp/bgpspeaker.py
@@ -86,6 +86,7 @@ from ryu.services.protocols.bgp.rtconf.common import REFRESH_STALEPATH_TIME
 from ryu.services.protocols.bgp.rtconf.common import LABEL_RANGE
 from ryu.services.protocols.bgp.rtconf.common import ALLOW_LOCAL_AS_IN_COUNT
 from ryu.services.protocols.bgp.rtconf.common import LOCAL_PREF
+from ryu.services.protocols.bgp.rtconf.common import NET_NS
 from ryu.services.protocols.bgp.rtconf.common import DEFAULT_LOCAL_PREF
 from ryu.services.protocols.bgp.rtconf import neighbors
 from ryu.services.protocols.bgp.rtconf import vrfs
@@ -290,6 +291,9 @@ class BGPSpeaker(object):
     It must be the string representation of an IPv4 address.
     If omitted, "router_id" is used for this field.
 
+    ``net_ns`` specifies a custom network namespace to use. If omitted, the
+    current process namespace is used.
+
     ``local_pref`` specifies the default local preference. It must be an
     integer.
     """
@@ -308,6 +312,7 @@ class BGPSpeaker(object):
                  label_range=DEFAULT_LABEL_RANGE,
                  allow_local_as_in_count=0,
                  cluster_id=None,
+                 net_ns=None, # JvB added
                  local_pref=DEFAULT_LOCAL_PREF):
         super(BGPSpeaker, self).__init__()
 
@@ -322,6 +327,7 @@ class BGPSpeaker(object):
             ALLOW_LOCAL_AS_IN_COUNT: allow_local_as_in_count,
             CLUSTER_ID: cluster_id,
             LOCAL_PREF: local_pref,
+            NET_NS: net_ns,
         }
         self._core_start(settings)
         self._init_signal_listeners()

--- a/ryu/services/protocols/bgp/core.py
+++ b/ryu/services/protocols/bgp/core.py
@@ -231,9 +231,17 @@ class CoreService(Factory, Activity):
         self.listen_sockets = {}
         if self._common_config.bgp_server_port != 0:
             for host in self._common_config.bgp_server_hosts:
-                server_thread, sockets = self._listen_tcp(
-                    (host, self._common_config.bgp_server_port),
-                    self.start_protocol)
+                if self._common_conf.net_ns is not None:
+                  import netns
+                  with netns.NetNS(nsname=self._common_conf.net_ns):
+                    server_thread, sockets = self._listen_tcp(
+                        (host, self._common_config.bgp_server_port),
+                        self.start_protocol)
+                else:
+                  server_thread, sockets = self._listen_tcp(
+                      (host, self._common_config.bgp_server_port),
+                      self.start_protocol)
+
                 self.listen_sockets.update(sockets)
                 server_thread.wait()
         processor_thread.wait()

--- a/ryu/services/protocols/bgp/peer.py
+++ b/ryu/services/protocols/bgp/peer.py
@@ -1293,11 +1293,23 @@ class Peer(Source, Sink, NeighborConfListener, Activity):
                 tcp_conn_timeout = self._common_conf.tcp_conn_timeout
                 try:
                     password = self._neigh_conf.password
-                    self._connect_tcp(peer_address,
-                                      client_factory,
-                                      time_out=tcp_conn_timeout,
-                                      bind_address=bind_addr,
-                                      password=password)
+
+                    if self._common_conf.net_ns is not None:
+                      import netns
+                      LOG.debug('Connecting to neighbor using netns %s',
+                                self._common_conf.net_ns)
+                      with netns.NetNS(nsname=self._common_conf.net_ns):
+                        self._connect_tcp(peer_address,
+                                          client_factory,
+                                          time_out=tcp_conn_timeout,
+                                          bind_address=bind_addr,
+                                          password=password)
+                    else:
+                      self._connect_tcp(peer_address,
+                                        client_factory,
+                                        time_out=tcp_conn_timeout,
+                                        bind_address=bind_addr,
+                                        password=password)
                 except socket.error:
                     self.state.bgp_state = const.BGP_FSM_ACTIVE
                     if LOG.isEnabledFor(logging.DEBUG):

--- a/ryu/services/protocols/bgp/rtconf/common.py
+++ b/ryu/services/protocols/bgp/rtconf/common.py
@@ -44,6 +44,7 @@ LABEL_RANGE = 'label_range'
 LABEL_RANGE_MAX = 'max'
 LABEL_RANGE_MIN = 'min'
 LOCAL_PREF = 'local_pref'
+NET_NS = 'net_ns'
 
 # Similar to Cisco command 'allowas-in'. Allows the local ASN in the path.
 # Facilitates auto rd, auto rt import/export
@@ -264,7 +265,7 @@ class CommonConf(BaseConf):
                                    MAX_PATH_EXT_RTFILTER_ALL,
                                    ALLOW_LOCAL_AS_IN_COUNT,
                                    CLUSTER_ID,
-                                   LOCAL_PREF])
+                                   LOCAL_PREF, NET_NS])
 
     def __init__(self, **kwargs):
         super(CommonConf, self).__init__(**kwargs)
@@ -294,6 +295,9 @@ class CommonConf(BaseConf):
             CLUSTER_ID, kwargs[ROUTER_ID], **kwargs)
         self._settings[LOCAL_PREF] = compute_optional_conf(
             LOCAL_PREF, DEFAULT_LOCAL_PREF, **kwargs)
+        self._settings[NET_NS] = compute_optional_conf(
+            NET_NS, None, **kwargs)
+
 
     # =========================================================================
     # Required attributes
@@ -353,6 +357,10 @@ class CommonConf(BaseConf):
     @property
     def local_pref(self):
         return self._settings[LOCAL_PREF]
+
+    @property
+    def net_ns(self):
+        return self._settings[NET_NS]
 
     @classmethod
     def get_opt_settings(self):

--- a/tools/optional-requires
+++ b/tools/optional-requires
@@ -3,3 +3,4 @@ ncclient  # OF-Config
 cryptography!=1.5.2  # Required by paramiko
 paramiko  # NETCONF, BGP speaker (SSH console)
 SQLAlchemy>=1.0.10,<1.1.0  # Zebra protocol service
+netns  # Support for network namespaces, optionally used for BGP TCP sockets


### PR DESCRIPTION
In some cases, BGP processes need to run in specific network namespaces. This patch adds support for an optional 'netns' parameter to enable this