### PR TITLE
Fix OFPPortStatsRequest (v1) docstring example

### DIFF
--- a/ryu/ofproto/ofproto_v1_0_parser.py
+++ b/ryu/ofproto/ofproto_v1_0_parser.py
@@ -3160,7 +3160,7 @@ class OFPPortStatsRequest(OFPStatsRequest):
             ofp = datapath.ofproto
             ofp_parser = datapath.ofproto_parser
 
-            req = ofp_parser.OFPPortStatsRequest(datapath, 0, ofp.OFPP_ANY)
+            req = ofp_parser.OFPPortStatsRequest(datapath, 0, ofp.OFPP_NONE)
             datapath.send_msg(req)
     """
 


### PR DESCRIPTION
As is the example gives:
```
    req = ofp_parser.OFPPortStatsRequest(datapath, 0, ofp.OFPP_ANY)
AttributeError: module 'ryu.ofproto.ofproto_v1_0' has no attribute 'OFPP_ANY'
```